### PR TITLE
fix: avoid causing an error in gatsby build

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -18,6 +18,7 @@ const findCssRules = config => config.module.rules.find(rule => Array.isArray(ru
  * @param rules
  */
 exports.onCreateWebpackConfig = ({ getConfig, stage, actions, loaders, rules }) => {
+    if (stage == 'build-html') return;
     const config = getConfig();
     const cssRules = findCssRules(config);
     const typingLoader = {


### PR DESCRIPTION
Fixes [this issue](https://github.com/nakario/gatsby-transformer-typescript-css-modules/issues/1)