### PR TITLE
[bug-fix] fixes issue with loading typingLoader in the wrong index

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -37,7 +37,7 @@ exports.onCreateWebpackConfig = ({ getConfig, stage, actions, loaders, rules }) 
     if (cssRules) {
         cssRules.oneOf.forEach((statement) => {
             const index = statement.use.findIndex(({ loader }) => loader.match(/\/css-loader\//))
-            if (index) {
+            if (index > -1) {
                 statement.use[index] = typingLoader
             }
             //If we didn't find a css-loader we can push the typingLoader onto the use statement


### PR DESCRIPTION
This is kind of an extension to #1, but it fixes the root cause of the error, as well as addressing other unexpected consequences of this bug.

`findIndex()` returns the true index value of the matched value.  If `css-loader` is in the first index, then it will return 0.  If `css-loader` is not found at all, it will return -1.

The error is being caused by the `typingLoader` being loaded into the wrong array position.  The `if (index)` check will return _**false**_ if it finds `css-loader` in the first position.  Conversely, it will return _**true**_ if it **doesn't** find `css-loader` at all.  Both of those possibilities have unexpected results.

---

Also, did the new version with the `build-html` check not get published?